### PR TITLE
fixed issue with input

### DIFF
--- a/library/src/main/java/com/mbientlab/metawear/impl/DataProcessorConfig.java
+++ b/library/src/main/java/com/mbientlab/metawear/impl/DataProcessorConfig.java
@@ -267,7 +267,7 @@ abstract class DataProcessorConfig {
             super(config[0]);
 
             isSigned = (config[1] & 0x1) == 0x1;
-            input = (byte) (((input >> 1) & 0x3) + 1);
+            input = (byte) (((config[1] >> 1) & 0x3) + 1);
             op = com.mbientlab.metawear.builder.filter.Comparison.values()[(config[1] >> 3) & 0x7];
             mode = ComparisonOutput.values()[(config[1] >> 6) & 0x3];
 


### PR DESCRIPTION
This doesn't seem correct, bit shifting over right on a zero input will always give back zero. I'm just guessing from the other operators that it's suppose to be config[1] where the sign is determined on the first bit and the next two bits determine the input. This is just a guess. 